### PR TITLE
Add support for multi-platform

### DIFF
--- a/Filtr.podspec
+++ b/Filtr.podspec
@@ -10,9 +10,9 @@ Pod::Spec.new do |s|
   s.author             = { "Daniel Lozano" => "dan@danielozano.com" }
   s.social_media_url   = "http://twitter.com/danlozanov"
 
-  s.platform     = :ios, "8.0"
-  s.platform     = :tvos
-  s.platform     = :osx, "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.0"
+  s.osx.deployment_target = "10.10"
 
   s.source       = { :git => "https://github.com/danlozano/Filtr.git", :tag => "#{s.version}" }
   s.source_files = "Filtr/Classes/**/*"

--- a/Filtr/Classes/EffectFilter.swift
+++ b/Filtr/Classes/EffectFilter.swift
@@ -22,9 +22,9 @@ public class EffectFilter: CIFilter {
     
     public let type: EffectFilterType
 
-    public var inputImage: CIImage?
+    @objc dynamic var inputImage: CIImage?
 
-    public var inputIntensity: Float = 1.0 {
+    @objc dynamic var inputIntensity: Float = 1.0 {
         didSet{
             colorCubeData = nil
         }


### PR DESCRIPTION
As per CocoaPods specs, we need to use `deployment_target`  instead of `platform` to support multiple platforms. The current default for tvOS is 9.0.

See more at:
- https://guides.cocoapods.org/syntax/podspec.html#deployment_target
- https://guides.cocoapods.org/syntax/podfile.html#platform